### PR TITLE
Fix Undeclared global variable `mcl_sounds`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -38,7 +38,7 @@ _doc_items_longdesc = moditems.STRING_ITEM
 
 local sounds
 
-if mcl_sounds then
+if minetest.get_modpath("mcl_sounds") then
    sounds = mcl_sounds.node_sound_metal_defaults()
 else
    if default.node_sound_metal_defaults then


### PR DESCRIPTION
Small fix to silence this warning:
```
2023-08-29 17:32:41: WARNING[Main]: Undeclared global variable "mcl_sounds" accessed at ~/.minetest/mods/ma_pops_furniture/init.lua:41
```