### PR TITLE
Fix deprecated setting accessors

### DIFF
--- a/fridge.lua
+++ b/fridge.lua
@@ -135,14 +135,14 @@ end
 --
 -- Node definitions
 --
-color1 = minetest.setting_get("color1") or "292421"
-color2 = minetest.setting_get("color2") or "0000FF"
-color3 = minetest.setting_get("color3") or "00FF00"
-color4 = minetest.setting_get("color4") or "F5F5F5"
-color5 = minetest.setting_get("color5") or "FF6103"
-color6 = minetest.setting_get("color6") or "FF0000"
-color7 = minetest.setting_get("color7") or "FFFF00"
-color8 = minetest.setting_get("color8") or "FF69B4"
+color1 = minetest.settings:get("color1") or "292421"
+color2 = minetest.settings:get("color2") or "0000FF"
+color3 = minetest.settings:get("color3") or "00FF00"
+color4 = minetest.settings:get("color4") or "F5F5F5"
+color5 = minetest.settings:get("color5") or "FF6103"
+color6 = minetest.settings:get("color6") or "FF0000"
+color7 = minetest.settings:get("color7") or "FFFF00"
+color8 = minetest.settings:get("color8") or "FF69B4"
 
 local fridges_list = {
 	{"black", "Darkened Fridge", color1}, 


### PR DESCRIPTION
Fix setting accessors depreciation:
```
2023-08-29 17:55:30: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at ~/.minetest/mods/ma_pops_furniture/fridge.lua:138)
2023-08-29 17:55:30: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at ~/.minetest/mods/ma_pops_furniture/fridge.lua:139)
2023-08-29 17:55:30: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at ~/.minetest/mods/ma_pops_furniture/fridge.lua:140)
2023-08-29 17:55:30: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at ~/.minetest/mods/ma_pops_furniture/fridge.lua:141)
2023-08-29 17:55:30: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at ~/.minetest/mods/ma_pops_furniture/fridge.lua:142)
2023-08-29 17:55:30: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at ~/.minetest/mods/ma_pops_furniture/fridge.lua:143)
2023-08-29 17:55:30: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at ~/.minetest/mods/ma_pops_furniture/fridge.lua:144)
2023-08-29 17:55:30: WARNING[Main]: WARNING: minetest.setting_* functions are deprecated.  Use methods on the minetest.settings object. (at ~/.minetest/mods/ma_pops_furniture/fridge.lua:145)

```