### PR TITLE
Fix set_physics_override crash, as it uses a table now

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -20,7 +20,9 @@ function ma_pops_furniture.sit(pos, node, clicker, pointed_thing)
 		pos.y = pos.y - 0.5
 		clicker:setpos(pos)
 		clicker:set_eye_offset({x=0, y=0, z=0}, {x=0, y=0, z=0})
-		clicker:set_physics_override(1, 1, 1)
+		clicker:set_physics_override({ speed = 1,
+                                               jump = 1,
+                                               gravity = 1 })
 		default.player_attached[player_name] = false
 		default.player_set_animation(clicker, "stand", 30)
 
@@ -28,7 +30,9 @@ function ma_pops_furniture.sit(pos, node, clicker, pointed_thing)
 			not ctrl.sneak and vector.equals(vel, {x=0,y=0,z=0}) then
 
 		clicker:set_eye_offset({x=0, y=-7, z=2}, {x=0, y=0, z=0})
-		clicker:set_physics_override(0, 0, 0)
+		clicker:set_physics_override({ speed = 0,
+                                               jump = 0,
+                                               gravity = 0 })
 		clicker:setpos(pos)
 		default.player_attached[player_name] = true
 		default.player_set_animation(clicker, "sit", 30)


### PR DESCRIPTION
In more recent versions of Minetest, using the (0,0,0) form of set_physics_override causes a crash instead of just a deprecation warning. The new tables have been valid since 5.1.0 at least.

I can still slide off the chair and go floating around; the player should probably be attached to an invisible entity when seated, but I'll just fix the crash for now.