### PR TITLE
Get colors into the namespace so crafts.lua can access them

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -1,3 +1,5 @@
+local fc = ma_pops_furniture.fridge_color
+
 minetest.register_craft({
 	output = 'ma_pops_furniture:smoke_detector',
 	recipe = {
@@ -409,7 +411,7 @@ local chair2_table = { --color
 
 for i in ipairs (chair2_table) do
 	local color = chair2_table[i][1]
-	
+
 minetest.register_craft({
 	output = 'ma_pops_furniture:chair2_'..color,
 	recipe = {
@@ -563,7 +565,7 @@ local sofa_table = { --color
 
 for i in ipairs (sofa_table) do
 	local color = sofa_table[i][1]
-	
+
 minetest.register_craft({
 	output = 'ma_pops_furniture:sofa_'..color,
 	recipe = {
@@ -668,7 +670,7 @@ for i in ipairs (unit_table) do
 	local name = unit_table[i][1]
 	local material = unit_table[i][2]
 	local invimg = unit_table[i][3]
-	
+
 minetest.register_craft({
 	output = 'ma_pops_furniture:e_u_'..material,
 	recipe = {
@@ -719,7 +721,7 @@ for i in ipairs (lamp_table) do
 	local name = lamp_table[i][1]
 	local color = lamp_table[i][2]
 	local hex = lamp_table[i][3]
-	
+
 minetest.register_craft({
 	output = 'ma_pops_furniture:lamp_off_'..color,
 	recipe = {
@@ -752,7 +754,7 @@ for i in ipairs (curtain_table) do
 	local name = curtain_table[i][1]
 	local color = curtain_table[i][2]
 	local hex = curtain_table[i][3]
-	
+
 minetest.register_craft({
 	output = 'ma_pops_furniture:curtains_'..color,
 	recipe = {
@@ -768,7 +770,7 @@ minetest.register_craft({
 	recipe =
 	{'ma_pops_furniture:curtains_'..color, 'ma_pops_furniture:curtains_'..color}
 })
-end 
+end
 
 minetest.register_craft({
 	output = 'ma_pops_furniture:blinds',
@@ -986,20 +988,20 @@ minetest.register_craft({
 
 --added craft
 local fridges_list = {
-	{"black", "Darkened Fridge", color1}, 
-	{"blue", "Blue Fridge", color2},
-	{"green", "Green Fridge", color3}, 
-	{"orange", "Orange Fridge", color5}, 
-	{"red", "Red Fridge", color6}, 
-	{"yellow", "Yellow Fridge", color7}, 
-	{"pink", "Pink Fridge", color8}
+    {"black", "Darkened Fridge", fc[1]},
+    {"blue", "Blue Fridge", fc[2]},
+    {"green", "Green Fridge", fc[3]},
+    {"orange", "Orange Fridge", fc[5]},
+    {"red", "Red Fridge", fc[6]},
+    {"yellow", "Yellow Fridge", fc[7]},
+    {"pink", "Pink Fridge", fc[8]}
 }
 
 for i, fridge in ipairs(fridges_list) do
     local colour = fridge[1]
     local fridgedesc = fridge[2]
     local colour2 = fridge[3]
-	
+
 minetest.register_craft({
 	type = "shapeless",
 	output = 'ma_pops_furniture:fridge_'..colour,

--- a/fridge.lua
+++ b/fridge.lua
@@ -135,6 +135,8 @@ end
 --
 -- Node definitions
 --
+ma_pops_furniture.fridge_color = {}
+
 local Settings = minetest.settings
 local function get_color(number)
     local col = Settings:get("ma_pops_fridge_color"..number)
@@ -142,24 +144,24 @@ local function get_color(number)
     return col
 end
 
-local color1 = get_color("1") or "292421"
-local color2 = get_color("2") or "0000FF"
-local color3 = get_color("3") or "00FF00"
-local color4 = get_color("4") or "F5F5F5"
-local color5 = get_color("5") or "FF6103"
-local color6 = get_color("6") or "FF0000"
-local color7 = get_color("7") or "FFFF00"
-local color8 = get_color("8") or "FF69B4"
+ma_pops_furniture.fridge_color[1] = get_color("1") or "292421"
+ma_pops_furniture.fridge_color[2] = get_color("2") or "0000FF"
+ma_pops_furniture.fridge_color[3] = get_color("3") or "00FF00"
+ma_pops_furniture.fridge_color[4] = get_color("4") or "F5F5F5"
+ma_pops_furniture.fridge_color[5] = get_color("5") or "FF6103"
+ma_pops_furniture.fridge_color[6] = get_color("6") or "FF0000"
+ma_pops_furniture.fridge_color[7] = get_color("7") or "FFFF00"
+ma_pops_furniture.fridge_color[8] = get_color("8") or "FF69B4"
 
 local fridges_list = {
-	{"black", "Darkened Fridge", color1},
-	{"blue", "Blue Fridge", color2},
-	{"green", "Green Fridge", color3},
-	{"white", "White Fridge", color4},
-	{"orange", "Orange Fridge", color5},
-	{"red", "Red Fridge", color6},
-	{"yellow", "Yellow Fridge", color7},
-	{"pink", "Pink Fridge", color8}
+	{"black", "Darkened Fridge", ma_pops_furniture.fridge_color[1]},
+	{"blue", "Blue Fridge", ma_pops_furniture.fridge_color[2]},
+	{"green", "Green Fridge", ma_pops_furniture.fridge_color[3]},
+	{"white", "White Fridge", ma_pops_furniture.fridge_color[3]},
+	{"orange", "Orange Fridge", ma_pops_furniture.fridge_color[5]},
+	{"red", "Red Fridge", ma_pops_furniture.fridge_color[6]},
+	{"yellow", "Yellow Fridge", ma_pops_furniture.fridge_color[7]},
+	{"pink", "Pink Fridge", ma_pops_furniture.fridge_color[8]}
 }
 
 for i, fridge in ipairs(fridges_list) do


### PR DESCRIPTION
I should remember to check these things in Minetest Game instead of my Asuna world, because Asuna generates so many warnings it's easy to miss things, like the warnings that crafts.lua accessed the global colorX variables.
 Moved them into the ma_pops_furniture namespace. It should probably have all of these things gathered into a single table, defining the various fridge appearances & descriptions, but this will work for now.

This will probably be it from me for a while, I need to work on Exile stuff :smile: 