### PR TITLE
Fix `Undeclared global variable "mcl_sounds" accessed at` in and micro-optimize `init.lua`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,14 +1,15 @@
 ma_pops_furniture = {}
 
 --GreenDimond's code from waffle mod
-local MP = minetest.get_modpath(minetest.get_current_modname())
+local MP = core.get_modpath(core.get_current_modname())
 local S, NS = dofile(MP.."/intllib.lua")
 
 ma_pops_furniture.intllib = S
-dofile(minetest.get_modpath('ma_pops_furniture')..'/intllib.lua')
+dofile(MP..'/intllib.lua')
 
 moditems = {}  -- switcher
 
+-- TODO: fix the comments
 if core.get_modpath("mcl_core") and mcl_core then -- means MineClone 2 is loaded, this is its core mod
 	moditems.IRON_ITEM = "mcl_core:iron_ingot"   -- MCL version of iron ingot
 	moditems.COAL_ITEM = "mcl_core:coalblock" -- MCL version of coal block
@@ -18,7 +19,6 @@ if core.get_modpath("mcl_core") and mcl_core then -- means MineClone 2 is loaded
 	moditems.INFOBOX_CAN = {}
 	moditems.INFOBOX_DUMP = {}
 	moditems.BOXART = "bgcolor[#d0d0d0;false]listcolors[#9d9d9d;#9d9d9d;#5c5c5c;#000000;#ffffff]" -- trying to imitate MCL boxart
-
 else         -- fallback, assume default (MineTest Game) is loaded, otherwise it will error anyway here.
 	moditems.IRON_ITEM = "default:steel_ingot"    -- MTG iron ingot
 	moditems.COAL_ITEM = "default:coalblock"      -- MTG coal block
@@ -38,7 +38,7 @@ _doc_items_longdesc = moditems.STRING_ITEM
 
 local sounds
 
-if mcl_sounds then
+if core.get_modpath("mcl_sounds") and mcl_sounds then
    sounds = mcl_sounds.node_sound_metal_defaults()
 else
    if default.node_sound_metal_defaults then
@@ -48,24 +48,24 @@ else
    end
 end
 
-dofile(minetest.get_modpath('ma_pops_furniture')..'/toaster.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/abm.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/bathroom.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/bedroom.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/kitchen.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/living_room.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/microwave.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/dining_room.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/outside.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/misc.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/oven.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/joyb.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/stereo.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/sofa.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/tv.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/toys.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/tools.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/functions.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/formspecs.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/fridge.lua')
-dofile(minetest.get_modpath('ma_pops_furniture')..'/crafts.lua')
+dofile(MP..'/toaster.lua')
+dofile(MP..'/abm.lua')
+dofile(MP..'/bathroom.lua')
+dofile(MP..'/bedroom.lua')
+dofile(MP..'/kitchen.lua')
+dofile(MP..'/living_room.lua')
+dofile(MP..'/microwave.lua')
+dofile(MP..'/dining_room.lua')
+dofile(MP..'/outside.lua')
+dofile(MP..'/misc.lua')
+dofile(MP..'/oven.lua')
+dofile(MP..'/joyb.lua')
+dofile(MP..'/stereo.lua')
+dofile(MP..'/sofa.lua')
+dofile(MP..'/tv.lua')
+dofile(MP..'/toys.lua')
+dofile(MP..'/tools.lua')
+dofile(MP..'/functions.lua')
+dofile(MP..'/formspecs.lua')
+dofile(MP..'/fridge.lua')
+dofile(MP..'/crafts.lua')


### PR DESCRIPTION
Tested with 'Luanti' 5.13.0 and 5.14.0.

- Switch `minetest` to `core`.
- Now checks the existence of the `mcl_sounds` submod before trying to access it, just like with the `mcl_core` before it.
- Micro-optimize the unnecessary multiple modpath lookups by using the already pre-existing lookup result in `MP`.
- The original comments are confusing and contradictory to my newbie's understanding of 'Luanti', so I just added a TODO comment for someone smarter to fix them.

Seems to still work like before.